### PR TITLE
Bump do-vue version to resolve ESM issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3282,7 +3282,7 @@
       }
     },
     "do-vue": {
-      "version": "git+https://github.com/do-community/do-vue.git#c0464d631dc2c8900060168aea3f98b929096347",
+      "version": "git+https://github.com/do-community/do-vue.git#e6e295d12879b92590874f901a4d40bb286522a3",
       "from": "git+https://github.com/do-community/do-vue.git",
       "requires": {
         "jsdom": "^15.2.1",


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** Deps

## What issue does this relate to?

cc https://github.com/do-community/do-vue/pull/14

### What should this PR do?

Resolves the console error seen in the production build relating to undefined vars in the tool footer, resulting in the footer not rendering. Bumping do-vue to a version that uses ESM everywhere allows scope hoisting to function correctly and removes the error.

### What are the acceptance criteria?

Tools builds correctly with scope hoisting and has no errors in console.