### PR TITLE
Replace Standard with Basic for Droplet type

### DIFF
--- a/src/bandwidth-tool/templates/droplets/active_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/active_droplet.vue
@@ -143,7 +143,7 @@ limitations under the License.
     const GeneralDropletIcon = require('../icons/general_droplet_icon');
     const KubernetesIcon = require('../icons/kubernetes_icon');
     const MemoryDropletIcon = require('../icons/memory_droplet_icon');
-    const StandardDropletIcon = require('../icons/standard_droplet_icon');
+    const BasicDropletIcon = require('../icons/basic_droplet_icon');
 
     module.exports = {
         name: 'ActiveDroplet',
@@ -157,7 +157,7 @@ limitations under the License.
             GeneralDropletIcon,
             KubernetesIcon,
             MemoryDropletIcon,
-            StandardDropletIcon,
+            BasicDropletIcon,
         },
         data() {
             return {
@@ -205,8 +205,8 @@ limitations under the License.
             iconType() {
                 if (this.$props.type === 'kubernetes') return 'KubernetesIcon';
                 switch (this.$props.droplet.type) {
-                case 'Standard':
-                    return 'StandardDropletIcon';
+                case 'Basic':
+                    return 'BasicDropletIcon';
 
                 case 'General Purpose':
                     return 'GeneralDropletIcon';

--- a/src/bandwidth-tool/templates/icons/basic_droplet_icon.vue
+++ b/src/bandwidth-tool/templates/icons/basic_droplet_icon.vue
@@ -33,6 +33,6 @@ limitations under the License.
 
 <script>
     module.exports = {
-        name: 'StandardDropletIcon',
+        name: 'BasicDropletIcon',
     };
 </script>

--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -79,12 +79,12 @@ limitations under the License.
         data() {
             return {
                 i18n,
-                category: 'Standard',
+                category: 'Basic',
                 categories: dropletTypes,
                 subCategory: undefined,
                 subCategories: [],
                 type: 'droplet',
-                display: getDroplets(this.$props.droplets, 'Standard'),
+                display: getDroplets(this.$props.droplets, 'Basic'),
             };
         },
         methods: {

--- a/src/bandwidth-tool/utils/dropletType.js
+++ b/src/bandwidth-tool/utils/dropletType.js
@@ -1,8 +1,24 @@
+/*
+Copyright 2020 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 const dropletType = slug => {
     const type = slug.split('-')[0];
     switch (type) {
         case 's':
-            return 'Standard';
+            return 'Basic';
 
         case 'g':
         case 'gd':
@@ -21,7 +37,7 @@ const dropletType = slug => {
     }
 };
 
-const dropletTypes = ['Standard', 'General Purpose', 'CPU-Optimized', 'Memory-Optimized']; // Missing 'Legacy'
+const dropletTypes = ['Basic', 'General Purpose', 'CPU-Optimized', 'Memory-Optimized']; // Missing 'Legacy'
 
 const dropletSubType = slug => {
     const type = slug.split('-')[0];


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue, JS

## What issue does this relate to?

N/A

### What should this PR do?

Replaces our use of "Standard" in Droplet types with the new "Basic" branding.

### What are the acceptance criteria?

All references to a standard Droplet are replaced with a basic Droplet.
