### PR TITLE
Hide unused Droplet types

### DIFF
--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -80,7 +80,7 @@ limitations under the License.
             return {
                 i18n,
                 category: 'Basic',
-                categories: dropletTypes,
+                categories: Object.keys(this.$props.droplets),
                 subCategory: undefined,
                 subCategories: [],
                 type: 'droplet',


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue

## What issue does this relate to?

N/A

### What should this PR do?

Hide Droplet types that have no available Droplets -- all Legacy Droplets were removed.

### What are the acceptance criteria?

Legacy category shouldn't show.