### PR TITLE
Fix initial category ordering

### DIFF
--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -80,7 +80,7 @@ limitations under the License.
             return {
                 i18n,
                 category: 'Basic',
-                categories: Object.keys(this.$props.droplets),
+                categories: dropletTypes.filter(c => Object.keys(this.$props.droplets).includes(c)),
                 subCategory: undefined,
                 subCategories: [],
                 type: 'droplet',


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue

## What issue does this relate to?

N/A

### What should this PR do?

Use `dropletTypes` for the picker categories and filter it, so that we retain the custom order.

### What are the acceptance criteria?

Picker categories are ordered basic, general-purpose, CPU, memory, storage.