### PR TITLE
Add warning on Droplets for overage cost

### DIFF
--- a/src/bandwidth-tool/i18n/en/templates/droplets/active_droplet.js
+++ b/src/bandwidth-tool/i18n/en/templates/droplets/active_droplet.js
@@ -20,6 +20,8 @@ module.exports = {
     monthlyCost: 'Monthly Droplet Cost',
     poolMonthlyCost: 'Monthly Pool Cost',
 
+    overageTooltip: 'The monthly Droplet cost shown here does not include the estimated bandwidth pool overage cost, shown above.',
+
     remove: 'Remove this Droplet',
     poolRemove: 'Remove this Kubernetes Pool',
 };

--- a/src/bandwidth-tool/scss/style.scss
+++ b/src/bandwidth-tool/scss/style.scss
@@ -36,6 +36,16 @@ $header: #0071fe;
     padding: 0;
   }
 
+  // These aren't links, use the help cursor, not pointer
+  .fa,
+  .far,
+  .fas,
+  .fab {
+    &.help {
+      cursor: help;
+    }
+  }
+
   .container {
     padding: ($margin * 4) 0;
     width: 100%;
@@ -265,6 +275,16 @@ $header: #0071fe;
 
           p {
             margin: 0;
+          }
+
+          + .overage {
+            cursor: help;
+            font-size: 1.25rem;
+            margin: 0 2.5rem 0 -1.5rem;
+
+            @media (max-width: $breakpoint) {
+              margin: 0 0 1rem;
+            }
           }
         }
 

--- a/src/bandwidth-tool/scss/style.scss
+++ b/src/bandwidth-tool/scss/style.scss
@@ -276,15 +276,15 @@ $header: #0071fe;
           p {
             margin: 0;
           }
+        }
 
-          + .overage {
-            cursor: help;
-            font-size: 1.25rem;
-            margin: 0 2.5rem 0 -1.5rem;
+        .overage {
+          cursor: help;
+          font-size: 1.25rem;
+          margin: 0 2.5rem 0 -1.5rem;
 
-            @media (max-width: $breakpoint) {
-              margin: 0 0 1rem;
-            }
+          @media (max-width: $breakpoint) {
+            margin: 0 0 1rem;
           }
         }
 

--- a/src/bandwidth-tool/templates/app.vue
+++ b/src/bandwidth-tool/templates/app.vue
@@ -51,6 +51,7 @@ limitations under the License.
                                     :droplet="droplet[0]"
                                     :type="droplet[1]"
                                     :class="focusedDropletClass(id)"
+                                    :overage="bandwidthOverage !== 0"
                                     @mouseenter.native="focusedDropletEnter(id)"
                                     @mouseleave.native="focusedDropletLeave(id)"
                                     @remove="removed(id)"

--- a/src/bandwidth-tool/templates/droplets/active_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/active_droplet.vue
@@ -114,12 +114,20 @@ limitations under the License.
             </div>
 
             <div class="tertiary-info">
-                <p><em><sup>$</sup>{{ dropletCost().toLocaleString() }}</em></p>
+                <p>
+                    <em><sup>$</sup>{{ dropletCost().toLocaleString() }}</em>
+                </p>
                 <p>
                     <sub v-if="type === 'kubernetes'">{{ i18n.templates.droplets.activeDroplet.poolMonthlyCost }}</sub>
                     <sub v-else>{{ i18n.templates.droplets.activeDroplet.monthlyCost }}</sub>
                 </p>
             </div>
+
+            <i v-if="overage"
+               v-tippy
+               :title="i18n.templates.droplets.activeDroplet.overageTooltip"
+               class="fas fa-exclamation-triangle overage"
+            ></i>
 
             <a v-tippy
                class="button is-tiny"
@@ -151,6 +159,7 @@ limitations under the License.
         props: {
             droplet: Object,
             type: String,
+            overage: Boolean,
         },
         components: {
             CPUDropletIcon,

--- a/src/bandwidth-tool/templates/droplets/active_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/active_droplet.vue
@@ -114,9 +114,7 @@ limitations under the License.
             </div>
 
             <div class="tertiary-info">
-                <p>
-                    <em><sup>$</sup>{{ dropletCost().toLocaleString() }}</em>
-                </p>
+                <p><em><sup>$</sup>{{ dropletCost().toLocaleString() }}</em></p>
                 <p>
                     <sub v-if="type === 'kubernetes'">{{ i18n.templates.droplets.activeDroplet.poolMonthlyCost }}</sub>
                     <sub v-else>{{ i18n.templates.droplets.activeDroplet.monthlyCost }}</sub>


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Active Droplet Vue/JS/SCSS

## What issue does this relate to?

N/A

### What should this PR do?

Based on [user feedback](https://twitter.com/fresskoma/status/1341411679586938881), this adds a warning displayed next to the monthly cost for each Droplet when there is an overage cost in the account bandwidth pool.

![image](https://user-images.githubusercontent.com/12371363/103229773-aa07ee80-492b-11eb-8a85-a607caa74790.png)

### What are the acceptance criteria?

Icon + tooltip make sense and clearly communicate the warning.