### PR TITLE
Ensure build exits on promise rejection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3501,11 +3501,11 @@
       "version": "git+https://github.com/do-community/do-bulma.git#32c6124f92518d45f1fd36b8c5304e2b67b0dcde",
       "from": "git+https://github.com/do-community/do-bulma.git",
       "requires": {
-        "bulma": "^0.9.0"
+        "bulma": "^0.9.1"
       }
     },
     "do-vue": {
-      "version": "git+https://github.com/do-community/do-vue.git#2440d4b1c633a52deb10735b2c978d4c287d4fd7",
+      "version": "git+https://github.com/do-community/do-vue.git#77669c92d701afbf7dc24d6d1f1c4185050a3858",
       "from": "git+https://github.com/do-community/do-vue.git",
       "requires": {
         "jsdom": "^16.4.0",
@@ -9703,9 +9703,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
-      "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ=="
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
+      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/src/build/getDroplets.js
+++ b/src/build/getDroplets.js
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 const fs = require('fs');
 const path = require('path');
 const get = require('./get');
@@ -17,4 +33,7 @@ const main = async () => {
     await save(results);
 };
 
-main();
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/src/build/getKubernetes.js
+++ b/src/build/getKubernetes.js
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 const fs = require('fs');
 const path = require('path');
 const get = require('./get');
@@ -11,4 +27,7 @@ const main = async () => {
     await save(data.options.sizes);
 };
 
-main();
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** Error handling in build scripts
- **Something else:** do-vue dep

## What issue does this relate to?

https://github.com/do-community/bandwidth-tool/runs/1657183575?check_suite_focus=true#step:5:129

### What should this PR do?

Updates do-vue to include https://github.com/do-community/do-vue/pull/23

Ensures the custom build scripts also exit on promise rejection.

### What are the acceptance criteria?

Tested locally, will now exit if anything fails.