### PR TITLE
Handle new Droplet types and variants

### DIFF
--- a/src/bandwidth-tool/templates/app.vue
+++ b/src/bandwidth-tool/templates/app.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ limitations under the License.
 
     const i18n = require('../i18n');
     const compareArrays = require('../utils/compareArrays');
-    const { dropletType, dropletSubType } = require('../utils/dropletType');
+    const { dropletType, dropletVariant } = require('../utils/dropletType');
     const dropletData = require('../../build/droplets');
 
     const Footer = require('do-vue/src/templates/footer').default;
@@ -114,7 +114,7 @@ limitations under the License.
         if (!type) continue;
         if (!(type in droplets)) droplets[type] = [];
         droplet.type = type;
-        droplet.subType = dropletSubType(droplet.slug);
+        droplet.variant = dropletVariant(droplet.slug);
         droplets[type].push(droplet);
     }
 

--- a/src/bandwidth-tool/templates/droplets/active_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/active_droplet.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -43,8 +43,8 @@ limitations under the License.
                 </p>
                 <p>{{ (droplet.memory / 1024).toLocaleString() }} {{ i18n.templates.droplets.droplet.memoryUnit }}</p>
                 <p>{{ droplet.disk.toLocaleString() }} {{ i18n.templates.droplets.droplet.diskSuffix }}</p>
-                <p v-if="droplet.subType">
-                    {{ droplet.subType }}
+                <p v-if="droplet.variant">
+                    {{ droplet.variant }}
                 </p>
                 <p><code>{{ droplet.slug }}</code></p>
             </div>

--- a/src/bandwidth-tool/templates/droplets/picker_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/picker_droplet.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,8 +45,8 @@ limitations under the License.
         </p>
         <p>{{ (droplet.memory / 1024).toLocaleString() }} {{ i18n.templates.droplets.droplet.memoryUnit }}</p>
         <p>{{ droplet.disk.toLocaleString() }} {{ i18n.templates.droplets.droplet.diskSuffix }}</p>
-        <p v-if="droplet.subType">
-            {{ droplet.subType }}
+        <p v-if="droplet.variant">
+            {{ droplet.variant }}
         </p>
         <p><code>{{ droplet.slug }}</code></p>
     </div>

--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ limitations under the License.
     <div class="picker">
         <div class="tabs">
             <ul>
-                <li v-for="cat in categories" :class="cat === category ? 'is-active' : ''">
-                    <a @click="setCategory(cat)">{{ cat }}</a>
+                <li v-for="type in dropletTypes" :class="type === dropletType ? 'is-active' : ''">
+                    <a @click="setDropletType(type)">{{ type }}</a>
                 </li>
             </ul>
         </div>
@@ -30,15 +30,15 @@ limitations under the License.
             <span>{{ i18n.templates.picker.kubernetes }}</span>
         </div>-->
 
-        <div v-if="subCategories.length" class="radio">
+        <div v-if="dropletVariants.length" class="radio">
             <PrettyRadio
-                v-for="subCat in subCategories"
-                :checked="subCat === subCategory"
+                v-for="variant in dropletVariants"
+                :checked="variant === dropletVariant"
                 class="p-default p-round"
-                name="subCategory"
-                @change="setSubCategory(subCat)"
+                name="variant"
+                @change="setDropletVariant(variant)"
             >
-                {{ subCat }}
+                {{ variant }}
             </PrettyRadio>
         </div>
 
@@ -79,57 +79,57 @@ limitations under the License.
         data() {
             return {
                 i18n,
-                category: 'Basic',
-                categories: dropletTypes.filter(c => Object.keys(this.$props.droplets).includes(c)),
-                subCategory: undefined,
-                subCategories: [],
+                dropletType: 'Basic',
+                dropletTypes: dropletTypes.filter(c => Object.keys(this.$props.droplets).includes(c)),
+                dropletVariant: null,
+                dropletVariants: [],
                 type: 'droplet',
                 display: getDroplets(this.$props.droplets, 'Basic'),
             };
         },
         methods: {
             getDroplets() {
-                let droplets = getDroplets(this.$props.droplets, this.$data.category);
+                let droplets = getDroplets(this.$props.droplets, this.$data.dropletType);
                 if (this.$data.type === 'kubernetes') droplets = droplets.filter(d => kubernetes.includes(d.slug));
                 return droplets;
             },
-            setCategory(cat) {
-                this.$data.category = cat;
+            setDropletType(type) {
+                this.$data.dropletType = type;
 
                 // Get droplets (kubernetes uses a limited subset)
                 const droplets = this.getDroplets();
 
-                // Get the subcats
-                const subCats = [...new Set(droplets.map(d => d.subType))].filter(d => !!d)
+                // Get the variants
+                const variants = [...new Set(droplets.map(d => d.variant))].filter(d => !!d)
                     .sort((a, b) => parseFloat(a.slice(0, a.indexOf('x'))) - parseFloat(b.slice(0, b.indexOf('x'))));
 
-                // Set the default subcat
-                this.$data.subCategory = subCats.length ? subCats[0] : undefined;
+                // Set the default variant
+                this.$data.dropletVariant = variants.length ? variants[0] : null;
 
-                // Set the subcats for picking (note: in k8s world, variants are't available and 1x is always used)
-                this.$data.subCategories = this.$data.type === 'kubernetes' ? [] : subCats;
+                // Set the variants for picking (note: in k8s world, variants aren't available and 1x is always used)
+                this.$data.dropletVariants = this.$data.type === 'kubernetes' ? [] : variants;
 
-                // Set the droplets to show, filtered by subcat
-                this.$data.display = droplets.filter(d => d.subType === this.$data.subCategory);
+                // Set the droplets to show, filtered by variant
+                this.$data.display = droplets.filter(d => d.variant === this.$data.dropletVariant);
             },
-            setSubCategory(subcat) {
-                this.$data.subCategory = subcat;
-                this.$data.display = this.getDroplets().filter(d => d.subType === this.$data.subCategory);
+            setDropletVariant(variant) {
+                this.$data.dropletVariant = variant;
+                this.$data.display = this.getDroplets().filter(d => d.variant === this.$data.dropletVariant);
             },
             toggleType() {
                 if (this.$data.type === 'droplet') this.$data.type = 'kubernetes';
                 else this.$data.type = 'droplet';
 
-                // Set the cats (use dropletTypes to preserve custom order)
+                // Set the types (use dropletTypes to preserve custom order)
                 let droplets = Object.values(this.$props.droplets).flat();
                 if (this.$data.type === 'kubernetes') droplets = droplets.filter(d => kubernetes.includes(d.slug));
-                const dropletCats = [...new Set(droplets.map(d => d.type))].filter(d => !!d);
-                const cats = dropletTypes.filter(c => dropletCats.includes(c));
-                this.$data.categories = cats;
-                this.$data.category = cats.includes(this.$data.category) ? this.$data.category : cats[0];
+                const activeDropletTypes = [...new Set(droplets.map(d => d.type))].filter(d => !!d);
+                const types = dropletTypes.filter(c => activeDropletTypes.includes(c));
+                this.$data.dropletTypes = types;
+                this.$data.dropletType = types.includes(this.$data.dropletType) ? this.$data.dropletType : types[0];
 
                 // Re-run category setting to deal with kubernetes not using all droplets
-                this.setCategory(this.$data.category);
+                this.setDropletType(this.$data.dropletType);
             },
             picked(slug) {
                 this.$emit('picked', slug, this.$data.type);

--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -79,13 +79,16 @@ limitations under the License.
         data() {
             return {
                 i18n,
-                dropletType: 'Basic',
+                dropletType: null,
                 dropletTypes: dropletTypes.filter(c => Object.keys(this.$props.droplets).includes(c)),
                 dropletVariant: null,
                 dropletVariants: [],
                 type: 'droplet',
-                display: getDroplets(this.$props.droplets, 'Basic'),
+                display: [],
             };
+        },
+        created() {
+            this.setDropletType(this.$data.dropletTypes[0]);
         },
         methods: {
             getDroplets() {

--- a/src/bandwidth-tool/utils/dropletType.js
+++ b/src/bandwidth-tool/utils/dropletType.js
@@ -16,9 +16,19 @@ limitations under the License.
 
 const dropletData = [
     {
-        regex: /^s-.*$/,
+        regex: /^s-\d+vcpu-\d+gb$/,
         type: 'Basic',
-        variant: null,
+        variant: 'Regular Intel',
+    },
+    {
+        regex: /^s-\d+vcpu-\d+gb-intel$/,
+        type: 'Basic',
+        variant: 'Premium Intel',
+    },
+    {
+        regex: /^s-\d+vcpu-\d+gb-amd$/,
+        type: 'Basic',
+        variant: 'Premium AMD',
     },
     {
         regex: /^g-.*$/,

--- a/src/bandwidth-tool/utils/dropletType.js
+++ b/src/bandwidth-tool/utils/dropletType.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,64 +14,69 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-const dropletType = slug => {
-    const type = slug.split('-')[0];
-    switch (type) {
-        case 's':
-            return 'Basic';
-
-        case 'g':
-        case 'gd':
-            return 'General Purpose';
-
-        case 'c':
-        case 'c2':
-            return 'CPU-Optimized';
-
-        case 'm':
-        case 'm3':
-        case 'm6':
-            return 'Memory-Optimized';
-
-        case 'so':
-        case 'so1_5':
-            return 'Storage-Optimized';
-
-        default:
-            return 'Legacy';
-    }
-};
+const dropletData = [
+    {
+        regex: /^s-.*$/,
+        type: 'Basic',
+        variant: null,
+    },
+    {
+        regex: /^g-.*$/,
+        type: 'General Purpose',
+        variant: '1x SSD',
+    },
+    {
+        regex: /^gd-.*$/,
+        type: 'General Purpose',
+        variant: '2x SSD',
+    },
+    {
+        regex: /^c-.*$/,
+        type: 'CPU-Optimized',
+        variant: '1x SSD',
+    },
+    {
+        regex: /^c2-.*$/,
+        type: 'CPU-Optimized',
+        variant: '2x SSD',
+    },
+    {
+        regex: /^m-.*$/,
+        type: 'Memory-Optimized',
+        variant: '1x SSD',
+    },
+    {
+        regex: /^m3-.*$/,
+        type: 'Memory-Optimized',
+        variant: '3x SSD',
+    },
+    {
+        regex: /^m6-.*$/,
+        type: 'Memory-Optimized',
+        variant: '6x SSD',
+    },
+    {
+        regex: /^so-.*$/,
+        type: 'Storage-Optimized',
+        variant: '1x SSD',
+    },
+    {
+        regex: /^so1_5-.*$/,
+        type: 'Storage-Optimized',
+        variant: '1.5x SSD',
+    },
+];
 
 const dropletTypes = ['Basic', 'General Purpose', 'CPU-Optimized', 'Memory-Optimized', 'Storage-Optimized', 'Legacy'];
 
-const dropletSubType = slug => {
-    const type = slug.split('-')[0];
-    switch (type) {
-        case 'g':
-            return '1x SSD';
-        case 'gd':
-            return '2x SSD';
-
-        case 'c':
-            return '1x SSD';
-        case 'c2':
-            return '2x SSD';
-
-        case 'm':
-            return '1x SSD';
-        case 'm3':
-            return '3x SSD';
-        case 'm6':
-            return '6x SSD';
-
-        case 'so':
-            return '1x SSD';
-        case 'so1_5':
-            return '1.5x SSD';
-
-        default:
-            return undefined;
-    }
+const dropletType = slug => {
+    const match = dropletData.find(data => slug.match(data.regex));
+    return match && match.type || 'Legacy';
 };
 
-module.exports = { dropletType, dropletTypes, dropletSubType };
+const dropletVariant = slug => {
+    const match = dropletData.find(data => slug.match(data.regex));
+    return match && match.variant || null;
+};
+
+module.exports = { dropletTypes, dropletType, dropletVariant };

--- a/src/build/getDroplets.js
+++ b/src/build/getDroplets.js
@@ -30,6 +30,27 @@ const main = async () => {
         results.push(...data.sizes);
         nextPage = data.links.pages.next;
     }
+
+    // Stub in the new AMD/Intel basic variants
+    // TODO: Remove this for public release
+    const regularBasic = results.filter(x => x.slug.startsWith('s-'));
+    for (const droplet of regularBasic) {
+        results.push(
+            {
+                ...droplet,
+                slug: `${droplet.slug}-intel`,
+                price_hourly: droplet.price_hourly * 1.2,
+                price_monthly: Math.floor(droplet.price_monthly * 1.2),
+            },
+            {
+                ...droplet,
+                slug: `${droplet.slug}-amd`,
+                price_hourly: droplet.price_hourly * 1.2,
+                price_monthly: Math.floor(droplet.price_monthly * 1.2),
+            },
+        );
+    }
+
     await save(results);
 };
 

--- a/src/build/getDroplets.js
+++ b/src/build/getDroplets.js
@@ -31,26 +31,6 @@ const main = async () => {
         nextPage = data.links.pages.next;
     }
 
-    // Stub in the new AMD/Intel basic variants
-    // TODO: Remove this for public release
-    const regularBasic = results.filter(x => x.slug.startsWith('s-'));
-    for (const droplet of regularBasic) {
-        results.push(
-            {
-                ...droplet,
-                slug: `${droplet.slug}-intel`,
-                price_hourly: droplet.price_hourly * 1.2,
-                price_monthly: Math.floor(droplet.price_monthly * 1.2),
-            },
-            {
-                ...droplet,
-                slug: `${droplet.slug}-amd`,
-                price_hourly: droplet.price_hourly * 1.2,
-                price_monthly: Math.floor(droplet.price_monthly * 1.2),
-            },
-        );
-    }
-
     await save(results);
 };
 


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Everything relating to Droplet types & variants

## What issue does this relate to?

### What should this PR do?

With the release of [Premium Intel & AMD Droplets](https://www.digitalocean.com/blog/premium-droplets-intel-cascade-lake-amd-epyc-rome/), new slug formats have been introduced.

This PR updates our parsing logic to support these new formats and display the variants correctly.

### What are the acceptance criteria?

Tool builds. Regular Intel, Premium Intel & Premium AMD Droplet variants show under the Basic type tab.