### PR TITLE
Reduce initial bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5432,14 +5432,6 @@
         "immediate": "~3.0.5"
       }
     },
-    "linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==",
-      "requires": {
-        "uc.micro": "^1.0.1"
-      }
-    },
     "listenercount": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
@@ -5623,39 +5615,10 @@
         "object-visit": "^1.0.0"
       }
     },
-    "markdown-it": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-      "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
-      "requires": {
-        "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "entities": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-          "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
-        }
-      }
-    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
-    },
-    "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -9941,11 +9904,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
       "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw=="
-    },
-    "uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -382,9 +382,9 @@
       "integrity": "sha512-6RglhutqrGFMO1MNUXp95RBuYIuc8wTnMAV5MUhLmjTOy78ncwOw7RgeQ/HeymkKXRhZd0s2DNrM1rL7unk3MQ=="
     },
     "@types/eslint": {
-      "version": "7.2.8",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.8.tgz",
-      "integrity": "sha512-RTKvBsfz0T8CKOGZMfuluDNyMFHnu5lvNr4hWEsQeHXH6FcmIDIozOyWMh36nLGMwVd5UFNXC2xztA8lln22MQ==",
+      "version": "7.2.9",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.9.tgz",
+      "integrity": "sha512-SdAAXZNvWfhtf3X3y1cbbCZhP3xyPh7mfTvzV6CgfWc/ZhiHpyr9bVroe2/RCHIf7gczaNcprhaBLsx0CCJHQA==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -664,9 +664,9 @@
       }
     },
     "acorn": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-      "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA=="
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+      "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -1413,19 +1413,9 @@
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
     },
     "chrome-trace-event": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
-      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
-      "requires": {
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
     },
     "circular-json": {
       "version": "0.3.3",
@@ -1998,9 +1988,9 @@
       }
     },
     "css-loader": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.0.tgz",
-      "integrity": "sha512-MfRo2MjEeLXMlUkeUwN71Vx5oc6EJnx5UQ4Yi9iUtYQvrPtwLUucYptz0hc6n++kdNcyF5olYBS4vPjJDAcLkw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.1.tgz",
+      "integrity": "sha512-YCyRzlt/jgG1xanXZDG/DHqAueOtXFHeusP9TS478oP1J++JSKOyEgGW1GHVoCj/rkS+GWOlBwqQJBr9yajQ9w==",
       "requires": {
         "camelcase": "^6.2.0",
         "cssesc": "^3.0.0",
@@ -2558,8 +2548,8 @@
       }
     },
     "do-vue": {
-      "version": "git+https://github.com/do-community/do-vue.git#00d159dfa41e2a0818f7b3fa4485724dc0f5c709",
-      "from": "git+https://github.com/do-community/do-vue.git",
+      "version": "git+https://github.com/do-community/do-vue.git#7e6e413723a37441cb3c481e24e7473689450777",
+      "from": "git+https://github.com/do-community/do-vue.git#MattIPv4/disable-prod-hot-reload",
       "requires": {
         "babel-loader": "^8.2.2",
         "browserify-fs": "^1.0.0",
@@ -5078,9 +5068,9 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.2.tgz",
-      "integrity": "sha512-JxNtPt9C1ut85boCbJmffaQ06NBnzkQY/MWO3YxPW8IWS38A26z+B1oBvA9LwKrytewdfymnhi4UNH3/RAgZrg==",
+      "version": "16.5.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
+      "integrity": "sha512-Qj1H+PEvUsOtdPJ056ewXM4UJPCi4hhLA8wpiz9F2YvsRBhuFsXxtrIFAgGBDynQA9isAMGE91PfUYbdMPXuTA==",
       "requires": {
         "abab": "^2.0.5",
         "acorn": "^8.1.0",
@@ -5671,12 +5661,19 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
       "requires": {
         "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
+        "picomatch": "^2.2.3"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+          "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
+        }
       }
     },
     "mime": {
@@ -6404,9 +6401,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "8.2.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-      "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+      "version": "8.2.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.10.tgz",
+      "integrity": "sha512-b/h7CPV7QEdrqIxtAf2j31U5ef05uBDuvoXv6L51Q4rcS1jdlXAVKJv+atCFdUXYl9dyTHGyoMzIepwowRJjFw==",
       "requires": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.22",
@@ -8008,9 +8005,9 @@
       }
     },
     "repeat-element": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ=="
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -9901,9 +9898,9 @@
       "integrity": "sha1-m7i6DoQfs/TPH+fCRenz+opf6Zw="
     },
     "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -10288,9 +10285,9 @@
       "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
     },
     "webpack": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.30.0.tgz",
-      "integrity": "sha512-Zr9NIri5yzpfmaMea2lSMV1UygbW0zQsSlGLMgKUm63ACXg6alhd1u4v5UBSBjzYKXJN6BNMGVM7w165e7NxYA==",
+      "version": "5.32.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.32.0.tgz",
+      "integrity": "sha512-jB9PrNMFnPRiZGnm/j3qfNqJmP3ViRzkuQMIf8za0dgOYvSLi/cgA+UEEGvik9EQHX1KYyGng5PgBTTzGrH9xg==",
       "requires": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.46",
@@ -10353,9 +10350,9 @@
       }
     },
     "webpack-bundle-analyzer": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.0.tgz",
-      "integrity": "sha512-9DhNa+aXpqdHk8LkLPTBU/dMfl84Y+WE2+KnfI6rSpNRNVKa0VGLjPd2pjFubDeqnWmulFggxmWBxhfJXZnR0g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.4.1.tgz",
+      "integrity": "sha512-j5m7WgytCkiVBoOGavzNokBOqxe6Mma13X1asfVYtKWM3wxBiRRu1u1iG0Iol5+qp9WgyhkMmBAcvjEfJ2bdDw==",
       "requires": {
         "acorn": "^8.0.4",
         "acorn-walk": "^8.0.0",
@@ -10890,9 +10887,9 @@
       "integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
     },
     "y18n": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.2.tgz",
-      "integrity": "sha512-DnBDwcL54b5xWMM/7RfFg4xs5amYxq2ot49aUfLjQSAracXkGvlZq0txzqr3Pa6Q0ayuCxBcwTzrPUScKY0O8w=="
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2548,8 +2548,8 @@
       }
     },
     "do-vue": {
-      "version": "git+https://github.com/do-community/do-vue.git#7e6e413723a37441cb3c481e24e7473689450777",
-      "from": "git+https://github.com/do-community/do-vue.git#MattIPv4/disable-prod-hot-reload",
+      "version": "git+https://github.com/do-community/do-vue.git#8bcfa55fde7653d8726d6f502c481a969f90e4e1",
+      "from": "git+https://github.com/do-community/do-vue.git",
       "requires": {
         "babel-loader": "^8.2.2",
         "browserify-fs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "do-bulma": "git+https://github.com/do-community/do-bulma.git",
     "do-vue": "git+https://github.com/do-community/do-vue.git",
     "exceljs": "^4.2.0",
-    "markdown-it": "^12.0.3",
     "node-fetch": "^2.6.1",
     "pretty-checkbox-vue": "^1.1.9",
     "query-string": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/do-community/bandwidth-tool#readme",
   "dependencies": {
     "do-bulma": "git+https://github.com/do-community/do-bulma.git",
-    "do-vue": "git+https://github.com/do-community/do-vue.git",
+    "do-vue": "git+https://github.com/do-community/do-vue.git#MattIPv4/disable-prod-hot-reload",
     "exceljs": "^4.2.0",
     "node-fetch": "^2.6.1",
     "pretty-checkbox-vue": "^1.1.9",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/do-community/bandwidth-tool#readme",
   "dependencies": {
     "do-bulma": "git+https://github.com/do-community/do-bulma.git",
-    "do-vue": "git+https://github.com/do-community/do-vue.git#MattIPv4/disable-prod-hot-reload",
+    "do-vue": "git+https://github.com/do-community/do-vue.git",
     "exceljs": "^4.2.0",
     "node-fetch": "^2.6.1",
     "pretty-checkbox-vue": "^1.1.9",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "pretty-checkbox-vue": "^1.1.9",
     "query-string": "^7.0.0",
     "vue": "^2.6.12",
-    "vue-hot-reload-api": "^2.3.3",
     "vue-tippy": "^4.10.0"
   },
   "devDependencies": {

--- a/src/bandwidth-tool/i18n/en/templates/costs.js
+++ b/src/bandwidth-tool/i18n/en/templates/costs.js
@@ -7,6 +7,7 @@ export default {
     estimatedOverage: 'Estimated Bandwidth Overage Cost',
     estimatedTotal: 'Estimated Total Costs',
 
+    generatingExport: 'Generating export...',
     exportAs: 'Export as',
 
     digitalOcean: 'DigitalOcean',

--- a/src/bandwidth-tool/i18n/en/templates/faqs.js
+++ b/src/bandwidth-tool/i18n/en/templates/faqs.js
@@ -1,6 +1,6 @@
 export default {
     title: 'Bandwidth FAQs',
-    forMoreInfo: 'For more information, please see our [bandwidth billing docs](https://www.digitalocean.com/docs/accounts/billing/bandwidth/).',
+    forMoreInfo: 'For more information, please see our <a href="https://www.digitalocean.com/docs/accounts/billing/bandwidth/">bandwidth billing docs</a>.',
     items: [
         {
             question: 'Do data transfers between my Droplets in the same datacenter count against my bandwidth usage?',
@@ -12,7 +12,7 @@ export default {
         },
         {
             question: 'Do data transfers using the Spaces service count against my bandwidth usage?',
-            answer: 'Spaces bandwidth usage is calculated and [billed differently](https://www.digitalocean.com/docs/accounts/billing/bandwidth/#spaces) than outbound transfers from your Droplets.',
+            answer: 'Spaces bandwidth usage is calculated and <a href="https://www.digitalocean.com/docs/accounts/billing/bandwidth/#spaces">billed differently</a> than outbound transfers from your Droplets.',
         },
         {
             question: 'Do data transfers from Droplets to Spaces count against my bandwidth?',

--- a/src/bandwidth-tool/templates/app.vue
+++ b/src/bandwidth-tool/templates/app.vue
@@ -144,6 +144,9 @@ limitations under the License.
                 focusedDroplet: null,
             };
         },
+        mounted() {
+            this.load();
+        },
         methods: {
             /**
              * URL loading logic
@@ -346,9 +349,6 @@ limitations under the License.
                 if (id === this.$data.focusedDroplet) return 'is-focused';
                 return 'is-unfocused';
             },
-        },
-        mounted() {
-            this.load();
         },
     };
 </script>

--- a/src/bandwidth-tool/templates/costs.vue
+++ b/src/bandwidth-tool/templates/costs.vue
@@ -96,7 +96,7 @@ limitations under the License.
             </tbody>
         </table>
 
-        <p v-if="generating">Generating export...</p>
+        <p v-if="generating">{{ i18n.templates.costs.generatingExport }}</p>
         <p v-else>
             {{ i18n.templates.costs.exportAs }}
             <a @click="() => xlsx(false)">XLSX</a> / <a @click="() => xlsx(true)">CSV</a>

--- a/src/bandwidth-tool/templates/costs.vue
+++ b/src/bandwidth-tool/templates/costs.vue
@@ -96,7 +96,9 @@ limitations under the License.
             </tbody>
         </table>
 
-        <p v-if="generating">{{ i18n.templates.costs.generatingExport }}</p>
+        <p v-if="generating">
+            {{ i18n.templates.costs.generatingExport }}
+        </p>
         <p v-else>
             {{ i18n.templates.costs.exportAs }}
             <a @click="() => xlsx(false)">XLSX</a> / <a @click="() => xlsx(true)">CSV</a>
@@ -130,7 +132,7 @@ limitations under the License.
             },
             async xlsx (asCsv) {
                 // Don't process if already running
-                if (this.generating) return
+                if (this.generating) return;
 
                 // Set ourselves as running
                 this.generating = true;

--- a/src/bandwidth-tool/templates/droplets/active_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/active_droplet.vue
@@ -154,11 +154,6 @@ limitations under the License.
 
     export default {
         name: 'ActiveDroplet',
-        props: {
-            droplet: Object,
-            type: String,
-            overage: Boolean,
-        },
         components: {
             CPUDropletIcon,
             DropletIcon,
@@ -168,6 +163,11 @@ limitations under the License.
             StorageDropletIcon,
             BasicDropletIcon,
         },
+        props: {
+            droplet: Object,
+            type: String,
+            overage: Boolean,
+        },
         data() {
             return {
                 i18n,
@@ -175,6 +175,30 @@ limitations under the License.
                 consumption: 0,
                 nodes: 1,
             };
+        },
+        computed: {
+            iconType() {
+                if (this.$props.type === 'kubernetes') return 'KubernetesIcon';
+                switch (this.$props.droplet.type) {
+                case 'Basic':
+                    return 'BasicDropletIcon';
+
+                case 'General Purpose':
+                    return 'GeneralDropletIcon';
+
+                case 'CPU-Optimized':
+                    return 'CPUDropletIcon';
+
+                case 'Memory-Optimized':
+                    return 'MemoryDropletIcon';
+
+                case 'Storage-Optimized':
+                    return 'StorageDropletIcon';
+
+                default:
+                    return 'DropletIcon';
+                }
+            },
         },
         watch: {
             hours() {
@@ -208,30 +232,6 @@ limitations under the License.
                 if (this.$data.hours >= this.maxHours())
                     return this.$props.droplet.price_monthly * this.nodeMultiplier();
                 return this.$props.droplet.price_hourly * this.cappedHours() * this.nodeMultiplier();
-            },
-        },
-        computed: {
-            iconType() {
-                if (this.$props.type === 'kubernetes') return 'KubernetesIcon';
-                switch (this.$props.droplet.type) {
-                case 'Basic':
-                    return 'BasicDropletIcon';
-
-                case 'General Purpose':
-                    return 'GeneralDropletIcon';
-
-                case 'CPU-Optimized':
-                    return 'CPUDropletIcon';
-
-                case 'Memory-Optimized':
-                    return 'MemoryDropletIcon';
-
-                case 'Storage-Optimized':
-                    return 'StorageDropletIcon';
-
-                default:
-                    return 'DropletIcon';
-                }
             },
         },
     };

--- a/src/bandwidth-tool/templates/faqs.vue
+++ b/src/bandwidth-tool/templates/faqs.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2020 DigitalOcean
+Copyright 2021 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,19 +17,17 @@ limitations under the License.
 <template>
     <div class="container faqs">
         <h2>{{ i18n.templates.faqs.title }}</h2>
-        <p class="has-text-muted" v-html="render(i18n.templates.faqs.forMoreInfo)"></p>
+        <p class="has-text-muted" v-html="i18n.templates.faqs.forMoreInfo"></p>
 
         <template v-for="item in i18n.templates.faqs.items">
             <h4>{{ item.question }}</h4>
-            <p v-html="render(item.answer)"></p>
+            <p v-html="item.answer"></p>
         </template>
     </div>
 </template>
 
 <script>
     import i18n from '../i18n';
-    const md = require('markdown-it')();
-    const render = text => md.renderInline(text);
 
     export default {
         name: 'FAQs',
@@ -37,9 +35,6 @@ limitations under the License.
             return {
                 i18n,
             };
-        },
-        methods: {
-            render,
         },
     };
 </script>

--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -33,6 +33,7 @@ limitations under the License.
         <div v-if="dropletVariants.length" class="radio">
             <PrettyRadio
                 v-for="variant in dropletVariants"
+                :key="variant"
                 :checked="variant === dropletVariant"
                 class="p-default p-round"
                 name="variant"
@@ -45,6 +46,7 @@ limitations under the License.
         <div class="panel-list">
             <PickerDroplet
                 v-for="droplet in display"
+                :key="droplet.slug"
                 :droplet="droplet"
                 :type="type"
                 @click.native="picked(droplet.slug)"

--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -18,8 +18,8 @@ limitations under the License.
     <div class="picker">
         <div class="tabs">
             <ul>
-                <li v-for="type in dropletTypes" :class="type === dropletType ? 'is-active' : ''">
-                    <a @click="setDropletType(type)">{{ type }}</a>
+                <li v-for="typeOpt in dropletTypes" :class="typeOpt === dropletType ? 'is-active' : ''">
+                    <a @click="setDropletType(typeOpt)">{{ typeOpt }}</a>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Costs exporting

## What issue does this relate to?

N/A

### What should this PR do?

Reduces the initial bundle size of the tool on page load by making the exceljs dependency async, only loading it if the user presses the export options for XLSX/CSV.

Further, this also removes our dependency on markdown-it, instead just hard-coding the HTML attributes for the FAQ items where needed.

### What are the acceptance criteria?

- Exporting a tool state to an XLSX file works as expected (including loading exceljs on-demand)
- Exporting a tool state to a CSV file works as expected (including loading exceljs on-demand)
- FAQs are rendered the same as in production