### PR TITLE
Update Basic Droplet type regex to catch $4 Droplet

### DIFF
--- a/src/bandwidth-tool/utils/dropletType.js
+++ b/src/bandwidth-tool/utils/dropletType.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 DigitalOcean
+Copyright 2022 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ limitations under the License.
 
 const dropletData = [
     {
-        regex: /^s-\d+vcpu-\d+gb$/,
+        regex: /^s-\d+vcpu-\d+(gb|mb)(-\d+gb)?$/,
         type: 'Basic',
         variant: 'Regular',
     },


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Droplet type detection

## What issue does this relate to?

N/A

### What should this PR do?

The $4 Droplet size is now available via the API, and has a new slug format that was not being caught by the existing Basic type regex. This PR updates the Basic type regex to detect `mb` (or `gb`) for the RAM, and also allows for the disk size (in `gb`) in the slug as well.

### What are the acceptance criteria?

$4 Droplet appears under the Basic tab in the Droplet picker.