### PR TITLE
Enable workflow dispatch for GitHub Pages builds

### DIFF
--- a/.github/workflows/gh-pages-workflow.yml
+++ b/.github/workflows/gh-pages-workflow.yml
@@ -6,6 +6,7 @@ on:
       - master
   schedule:
     - cron: '0 15 * * *'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Type of Change

- **Something else:** Actions

## What issue does this relate to?

N/A

### What should this PR do?

Enables workflow dispatching as a trigger for the GitHub Pages build flow, allowing for manual runs on demand.

### What are the acceptance criteria?

Workflow dispatch enabled for the workflow.