### PR TITLE
Update workflows with v3 actions + permissions

### DIFF
--- a/.github/workflows/do-spaces-workflow.yml
+++ b/.github/workflows/do-spaces-workflow.yml
@@ -2,26 +2,24 @@ name: Test and Deploy to DigitalOcean Spaces
 
 on: push
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
+    - name: Use Node.js
+      uses: actions/setup-node@v3
       with:
-        persist-credentials: false
+        node-version-file: .nvmrc
+        cache: npm
 
-    - name: Read .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      id: nvm
-
-    - name: Use Node.js (.nvmrc)
-      uses: actions/setup-node@v1
-      with:
-        node-version: "${{ steps.nvm.outputs.NVMRC }}"
-
-    - name: npm ci, test, and build
+    - name: Install dependencies, test, and build
       run: |
         npm ci
         npm test
@@ -36,7 +34,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: ${{ secrets.SPACES_REGION }}
 
-    - name: Leave a comment
+    - name: Leave a comment on commit
       run: npm run deploy:spaces:comment
       env:
         REPO_NAME: ${{ github.repository }}

--- a/.github/workflows/gh-pages-workflow.yml
+++ b/.github/workflows/gh-pages-workflow.yml
@@ -8,26 +8,28 @@ on:
     - cron: '0 15 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
+concurrency:
+  group: gh-pages-workflow
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+
+    - name: Use Node.js
+      uses: actions/setup-node@v3
       with:
-        persist-credentials: false
+        node-version-file: .nvmrc
+        cache: npm
 
-    - name: Read .nvmrc
-      run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
-      id: nvm
-
-    - name: Use Node.js (.nvmrc)
-      uses: actions/setup-node@v1
-      with:
-        node-version: "${{ steps.nvm.outputs.NVMRC }}"
-
-    - name: npm ci, test, and build
+    - name: Install dependencies, test, and build
       run: |
         npm ci
         npm test
@@ -36,10 +38,8 @@ jobs:
         DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
 
     - name: Deploy master to GitHub Pages
-      uses: JamesIves/github-pages-deploy-action@3.7.1
+      uses: JamesIves/github-pages-deploy-action@v4
       with:
-        ACCESS_TOKEN: ${{ secrets.DEV_GITHUB_TOKEN }}
-        BRANCH: gh-pages
-        FOLDER: dist
-        CLEAN: true
-        SINGLE_COMMIT: true
+        folder: dist
+        clean: true
+        single-commit: true


### PR DESCRIPTION
## Type of Change

- **Something else:** Actions workflows

## What issue does this relate to?

cc https://github.com/do-community/do-bulma/pull/53

### What should this PR do?

Updates Actions workflows to use checkout/setup-node@v3, use github-pages-deploy-action@v4 (which no longer needs a custom token), sets the permissions for the Spaces workflow to explicitly include write access to the contents so commit comments can be added, and sets the Pages workflow to explicitly include write access to the contents so it can deploy.

### What are the acceptance criteria?

Workflows continue to run.