### PR TITLE
Fix Droplet cost below max hours

### DIFF
--- a/src/bandwidth-tool/templates/droplets/active_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/active_droplet.vue
@@ -241,7 +241,7 @@ limitations under the License.
             dropletCost() {
                 if (this.$data.hours >= this.maxHours())
                     return this.$props.droplet.price.monthly * this.nodeMultiplier();
-                return this.$props.droplet.price.monthly * this.cappedHours() * this.nodeMultiplier();
+                return this.$props.droplet.price.hourly * this.cappedHours() * this.nodeMultiplier();
             },
         },
     };


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Active Droplet cost

## What issue does this relate to?

N/A

### What should this PR do?

When calculating the price for an active Droplet in the tool that has its hours configured to a value below the maximum monthly hours, the tool should use the hourly cost multiplied by the hours, not the monthly cost.

### What are the acceptance criteria?

As the hours for a Droplet are reduced below the monthly cap (672), the price begins to decrease as expected, rather than jumping up massively.