### PR TITLE
Allow for nested variants on Droplets

### DIFF
--- a/src/bandwidth-tool/scss/style.scss
+++ b/src/bandwidth-tool/scss/style.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -511,97 +511,57 @@ $header: #0071fe;
     }
   }
 
-  .droplet-picker {
-    .picker {
-      .tabs {
-        margin: 0;
+  .picker {
+    .tabs {
+      margin: 0;
+
+      @media (max-width: $breakpoint) {
+        margin: 0 0 $margin;
+      }
+    }
+
+    .switch {
+      margin: 0 .5rem .5rem;
+      padding: 0 .15rem;
+
+      > span {
+        display: inline-block;
 
         @media (max-width: $breakpoint) {
-          margin: 0 0 $margin;
+          display: block;
         }
       }
 
-      .switch {
-        margin: 0 .5rem .5rem;
-        padding: 0 .15rem;
+      .pretty {
+        &.p-fill {
+          &.p-switch {
+            line-height: 1.1;
+            margin: 0 .5rem;
 
-        > span {
-          display: inline-block;
-
-          @media (max-width: $breakpoint) {
-            display: block;
-          }
-        }
-
-        .pretty {
-          &.p-fill {
-            &.p-switch {
-              line-height: 1.1;
-              margin: 0 .25rem;
-
-              @media (max-width: $breakpoint) {
-                margin: .75rem 0;
-                transform: rotate(90deg);
-              }
-
-              input {
-                &:checked {
-                  ~ .state {
-                    label {
-                      &::after {
-                        left: calc(1em - 2px);
-
-                        @media (max-width: $breakpoint) {
-                          left: calc(1em + 1px);
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-
-              .state {
-                &::before {
-                  height: 1em;
-                  top: 0;
-                  transition: all $transition;
-                }
-
-                label {
-                  @include font-regular;
-
-                  min-width: 2em;
-                  text-indent: 0;
-
-                  &::before,
-                  &::after {
-                    height: 1em;
-                    top: 0;
-                    transition: all $transition;
-                    width: 1em;
-
-                    @media (max-width: $breakpoint) {
-                      left: 1px;
-                      top: 1px;
-                    }
-                  }
-                }
-              }
+            @media (max-width: $breakpoint) {
+              margin: .75rem 0;
+              transform: rotate(90deg);
             }
           }
         }
       }
+    }
 
-      .radio {
-        margin: .5rem;
+    .radio {
+      margin: .5rem;
 
-        label {
-          @include font-regular;
+      label {
+        @include font-regular;
 
-          color: $text;
-          font-size: 1rem;
-        }
+        color: $text;
+        font-size: 1rem;
       }
+    }
+
+    .variants {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem 0;
     }
   }
 

--- a/src/bandwidth-tool/scss/style.scss
+++ b/src/bandwidth-tool/scss/style.scss
@@ -234,8 +234,7 @@ $header: #0071fe;
           .secondary-info {
             align-items: center;
             display: flex;
-            flex-direction: row;
-            flex-wrap: wrap;
+            flex-flow: row wrap;
 
             p {
               margin: 0;

--- a/src/bandwidth-tool/scss/style.scss
+++ b/src/bandwidth-tool/scss/style.scss
@@ -235,10 +235,7 @@ $header: #0071fe;
             align-items: center;
             display: flex;
             flex-direction: row;
-
-            @media (max-width: $breakpoint) {
-              flex-wrap: wrap;
-            }
+            flex-wrap: wrap;
 
             p {
               margin: 0;
@@ -294,6 +291,8 @@ $header: #0071fe;
         }
 
         .right {
+          flex-shrink: 0;
+
           @media (max-width: $breakpoint) {
             flex-direction: column;
             margin: 0;

--- a/src/bandwidth-tool/templates/app.vue
+++ b/src/bandwidth-tool/templates/app.vue
@@ -79,7 +79,7 @@ limitations under the License.
                         ></Costs>
                     </div>
 
-                    <Picker :droplets="droplets" @picked="picked"></Picker>
+                    <Picker :droplets="droplets" :kubernetes="kubernetesEnabled" @picked="picked"></Picker>
                 </div>
             </div>
         </div>
@@ -142,6 +142,7 @@ limitations under the License.
                 bandwidthOverage: 0,
                 dropletCost: 0,
                 focusedDroplet: null,
+                kubernetesEnabled: false,
             };
         },
         mounted() {
@@ -199,7 +200,8 @@ limitations under the License.
                     if (!droplet) continue;
                     const keys = Object.keys(this.$data.activeDroplets).map(x => parseInt(x));
                     const id = keys.length ? Math.max(...keys) + 1 : 0;
-                    this.$data.activeDroplets[id] = [droplet, item.type];
+                    const type = item.type === 'kubernetes' && this.$data.kubernetesEnabled ? 'kubernetes' : 'droplet';
+                    this.$data.activeDroplets[id] = [droplet, type];
                     this.$data.hasActiveDroplets = !!Object.keys(this.$data.activeDroplets).length;
 
                     // Once rendered, set the data in the ref

--- a/src/bandwidth-tool/templates/app.vue
+++ b/src/bandwidth-tool/templates/app.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -95,7 +95,6 @@ limitations under the License.
 
     import i18n from '../i18n';
     import compareArrays from '../utils/compareArrays';
-    import { camelToTitleCase } from '../utils/titleCase';
     import dropletsData from '../../build/droplets';
 
     import Footer from 'do-vue/src/templates/footer';
@@ -109,11 +108,7 @@ limitations under the License.
     // Build the Droplet data
     const droplets = dropletsData.reduce((obj, droplet) => ({
         ...obj,
-        [droplet.type]: (obj[droplet.type] || []).concat(({
-            ...droplet,
-            variant: (droplet.variant && camelToTitleCase(droplet.variant))
-                || (droplet.ssd.variant ? `${droplet.ssd.variant}x SSD` : null),
-        })),
+        [droplet.type]: (obj[droplet.type] || []).concat(droplet),
     }), {});
     const dropletsBySlug = Object.keys(droplets).reduce((obj, type) => ({
         ...obj,

--- a/src/bandwidth-tool/templates/droplets/active_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/active_droplet.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -43,9 +43,7 @@ limitations under the License.
                 </p>
                 <p>{{ droplet.memory.toLocaleString() }} {{ i18n.templates.droplets.droplet.memoryUnit }}</p>
                 <p>{{ droplet.ssd.size.toLocaleString() }} {{ i18n.templates.droplets.droplet.diskSuffix }}</p>
-                <p>
-                    {{ `${dropletTypes[droplet.type] || 'Legacy'}${droplet.variant && `: ${droplet.variant}`}` }}
-                </p>
+                <p>{{ `${dropletTypes[droplet.type] || 'Legacy'}${variant}` }}</p>
                 <p><code>{{ droplet.slug }}</code></p>
             </div>
         </div>
@@ -147,6 +145,7 @@ limitations under the License.
 <script>
     import i18n from '../../i18n';
     import dropletTypes from '../../utils/dropletTypes';
+    import { camelToTitleCase } from '../../utils/titleCase';
     import { directive } from 'vue-tippy';
 
     import CPUDropletIcon from '../icons/cpu_droplet_icon';
@@ -209,6 +208,12 @@ limitations under the License.
                     return 'DropletIcon';
                 }
             },
+            variant() {
+                const variants = (this.$props.droplet.variant || []).map(camelToTitleCase)
+                    .concat(this.$props.type === 'kubernetes' || !this.$props.droplet.ssd.variant
+                        ? [] : `${this.$props.droplet.ssd.variant}x SSD`);
+                return variants.length ? `: ${variants.join(', ')}` : '';
+            },
         },
         watch: {
             hours() {
@@ -222,6 +227,7 @@ limitations under the License.
             },
         },
         methods: {
+            camelToTitleCase,
             remove() {
                 this.$emit('remove');
             },

--- a/src/bandwidth-tool/templates/droplets/picker_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/picker_droplet.vue
@@ -45,7 +45,9 @@ limitations under the License.
         </p>
         <p>{{ droplet.memory.toLocaleString() }} {{ i18n.templates.droplets.droplet.memoryUnit }}</p>
         <p>{{ droplet.ssd.size.toLocaleString() }} {{ i18n.templates.droplets.droplet.diskSuffix }}</p>
-        <p v-if="droplet.variant?.length">{{ droplet.variant.join(', ') }}</p>
+        <p v-if="droplet.variant?.length">
+            {{ droplet.variant.join(', ') }}
+        </p>
         <p><code>{{ droplet.slug }}</code></p>
     </div>
 </template>

--- a/src/bandwidth-tool/templates/droplets/picker_droplet.vue
+++ b/src/bandwidth-tool/templates/droplets/picker_droplet.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,9 +45,7 @@ limitations under the License.
         </p>
         <p>{{ droplet.memory.toLocaleString() }} {{ i18n.templates.droplets.droplet.memoryUnit }}</p>
         <p>{{ droplet.ssd.size.toLocaleString() }} {{ i18n.templates.droplets.droplet.diskSuffix }}</p>
-        <p v-if="droplet.variant">
-            {{ droplet.variant }}
-        </p>
+        <p v-if="droplet.variant?.length">{{ droplet.variant.join(', ') }}</p>
         <p><code>{{ droplet.slug }}</code></p>
     </div>
 </template>

--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -189,7 +189,7 @@ limitations under the License.
                 // Inject the variants for each Droplet
                 return dropletsFiltered.map(droplet => ({
                     ...droplet,
-                    variant: droplet.variant.map(camelToTitleCase)
+                    variant: (droplet.variant || []).map(camelToTitleCase)
                         .concat(isK8s || !droplet.ssd.variant ? [] : `${droplet.ssd.variant}x SSD`),
                 }));
             },

--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -65,7 +65,7 @@ limitations under the License.
     import dropletTypes from '../utils/dropletTypes';
     import kubernetesData from '../../build/kubernetes';
 
-    import PrettyCheck from 'do-vue/src/templates/pretty-checkbox-vue/pretty_check';
+    // import PrettyCheck from 'do-vue/src/templates/pretty-checkbox-vue/pretty_check';
     import PrettyRadio from 'do-vue/src/templates/pretty-checkbox-vue/pretty_radio';
     import { camelToTitleCase } from '../utils/titleCase.js';
     import PickerDroplet from './droplets/picker_droplet';
@@ -130,6 +130,7 @@ limitations under the License.
     const getValidVariant = (all, selected) => {
         const result = [];
         const prev = [ ...selected ];
+        // eslint-disable-next-line no-constant-condition
         while (true) {
             const available = sortVariants(getAvailableVariants(all, result));
             if (!available.length) return result;
@@ -152,7 +153,7 @@ limitations under the License.
         name: 'Picker',
         components: {
             PickerDroplet,
-            PrettyCheck,
+            // PrettyCheck,
             PrettyRadio,
         },
         props: {

--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,29 +18,33 @@ limitations under the License.
     <div class="picker">
         <div class="tabs">
             <ul>
-                <li v-for="(typeVal, typeKey) in dropletTypes" :class="typeKey === dropletType ? 'is-active' : ''">
+                <li v-for="(typeVal, typeKey) in availableTypes" :class="typeKey === selectedType ? 'is-active' : ''">
                     <a @click="setDropletType(typeKey)">{{ typeVal }}</a>
                 </li>
             </ul>
         </div>
 
-        <!--<div class="switch">
-            <span>{{ i18n.templates.picker.droplets }}</span>
-            <PrettyCheck class="p-switch p-fill" :checked="false" @change="toggleType"></PrettyCheck>
-            <span>{{ i18n.templates.picker.kubernetes }}</span>
+        <!--<div class="variants">
+            <div class="switch">
+                <span>{{ i18n.templates.picker.droplets }}</span>
+                <PrettyCheck class="p-switch p-fill" :checked="type === 'kubernetes'" @change="toggleType"></PrettyCheck>
+                <span>{{ i18n.templates.picker.kubernetes }}</span>
+            </div>
         </div>-->
 
-        <div v-if="dropletVariants.length" class="radio">
-            <PrettyRadio
-                v-for="variant in dropletVariants"
-                :key="variant"
-                :checked="variant === dropletVariant"
-                class="p-default p-round"
-                name="variant"
-                @change="setDropletVariant(variant)"
-            >
-                {{ variant }}
-            </PrettyRadio>
+        <div class="variants">
+            <div v-for="(selectedVariant, idx) in selectedVariants" class="radio">
+                <PrettyRadio
+                    v-for="availableVariant in getAvailableVariants(availableVariants, selectedVariants.slice(0, idx))"
+                    :key="selectedVariants.slice(0, idx).concat(availableVariant).join('-')"
+                    :checked="availableVariant === selectedVariant"
+                    class="p-default p-round"
+                    :name="`variant-${selectedVariants.slice(0, idx).join('-')}`"
+                    @change="setDropletVariant(availableVariant, idx)"
+                >
+                    {{ availableVariant }}
+                </PrettyRadio>
+            </div>
         </div>
 
         <div class="panel-list">
@@ -57,20 +61,98 @@ limitations under the License.
 
 <script>
     import i18n from '../i18n';
+    import compareArrays from '../utils/compareArrays.js';
     import dropletTypes from '../utils/dropletTypes';
     import kubernetesData from '../../build/kubernetes';
 
-    // import PrettyCheck from 'do-vue/src/templates/pretty-checkbox-vue/pretty_check';
+    import PrettyCheck from 'do-vue/src/templates/pretty-checkbox-vue/pretty_check';
     import PrettyRadio from 'do-vue/src/templates/pretty-checkbox-vue/pretty_radio';
+    import { camelToTitleCase } from '../utils/titleCase.js';
     import PickerDroplet from './droplets/picker_droplet';
 
     const kubernetes = kubernetesData.map(x => x.slug);
+
+    /**
+     * Convert a Droplet variant array into a nested object
+     *
+     * @param {{ variant: string[] | undefined }} droplet Droplet object
+     * @param {{ [key: string]: any }} [existing={}] Existing variants object
+     * @returns {{ [key: string]: any }} Variants object
+      */
+    const getVariants = (droplet, existing = {}) => {
+        if (!droplet.variant) return existing;
+        const variants = { ...existing };
+        droplet.variant.reduce((parent, variant) => {
+            parent[variant] = { ...(parent[variant] || {}) };
+            return parent[variant];
+        }, variants);
+        return variants;
+    };
+
+    /**
+     * Get the available variants for a given variant array
+     * @param {{ [key: string]: any }} all All variants
+     * @param {string[]} selected Selected variants
+     * @returns {string[]} Available variants
+      */
+    const getAvailableVariants = (all, selected) => {
+        if (!selected.length) return Object.keys(all);
+        return Object.keys(selected.reduce((acc, variant) => {
+            if (!acc[variant]) throw new Error(`Invalid variant: ${variant}`);
+            return acc[variant];
+        }, all));
+    };
+
+    /**
+     * Sort an array of variant names
+     *
+     * @param {string[]} variants Variants
+     * @returns {string[]} Sorted variants
+      */
+    const sortVariants = variants => [ ...variants ].sort((a, b) => {
+        const aMatch = a.match(/^(\d+(?:\.\d+)?)x SSD$/);
+        const bMatch = b.match(/^(\d+(?:\.\d+)?)x SSD$/);
+
+        if (aMatch && bMatch) return parseFloat(aMatch[1]) - parseFloat(bMatch[1]);
+        if (aMatch) return -1;
+        if (bMatch) return 1;
+
+        return variants.indexOf(a) - variants.indexOf(b);
+    });
+
+    /**
+     * Get a valid variant chain for a given selected chain
+     *
+     * @param {{ [key: string]: any }} all All variants
+     * @param {string[]} selected Selected variant chain
+     * @returns {string[]} Valid variant chain
+      */
+    const getValidVariant = (all, selected) => {
+        const result = [];
+        const prev = [ ...selected ];
+        while (true) {
+            const available = sortVariants(getAvailableVariants(all, result));
+            if (!available.length) return result;
+
+            // If there is a previous variant, and it is available, use it
+            if (prev.length) {
+                const next = prev.shift();
+                if (available.includes(next)) {
+                    result.push(next);
+                    continue;
+                }
+            }
+
+            // Otherwise, use the first available variant
+            result.push(available[0]);
+        }
+    };
 
     export default {
         name: 'Picker',
         components: {
             PickerDroplet,
-            // PrettyCheck,
+            PrettyCheck,
             PrettyRadio,
         },
         props: {
@@ -79,10 +161,11 @@ limitations under the License.
         data() {
             return {
                 i18n,
-                dropletType: null,
-                dropletTypes,
-                dropletVariant: null,
-                dropletVariants: [],
+                selectedType: null,
+                availableTypes: dropletTypes,
+                selectedVariants: [],
+                availableVariants: {},
+                getAvailableVariants,
                 type: 'droplet',
                 display: [],
             };
@@ -92,49 +175,53 @@ limitations under the License.
         },
         methods: {
             getDroplets() {
-                const droplets = [ ...this.$props.droplets[this.$data.dropletType] ]
-                    .sort((a, b) => a.price.monthly - b.price.monthly);
-                return this.$data.type === 'kubernetes'
-                    ? droplets.filter(d => kubernetes.includes(d.slug))
-                    : droplets;
-            },
-            setDropletType(type) {
-                this.$data.dropletType = type;
+                const isK8s = this.$data.type === 'kubernetes';
 
+                // Get the Droplets for this type
+                const dropletsType = [ ...this.$props.droplets[this.$data.selectedType] ]
+                    .sort((a, b) => a.price.monthly - b.price.monthly);
+
+                // Filter out Droplets if we're in kubernetes mode
+                const dropletsFiltered = isK8s
+                    ? dropletsType.filter(d => kubernetes.includes(d.slug))
+                    : dropletsType;
+
+                // Inject the variants for each Droplet
+                return dropletsFiltered.map(droplet => ({
+                    ...droplet,
+                    variant: droplet.variant.map(camelToTitleCase)
+                        .concat(isK8s || !droplet.ssd.variant ? [] : `${droplet.ssd.variant}x SSD`),
+                }));
+            },
+            updateDroplets() {
                 // Get droplets (kubernetes uses a limited subset)
                 const droplets = this.getDroplets();
 
-                // Get the variants
-                const variants = [ ...new Set(droplets.map(d => d.variant)) ].filter(d => !!d);
-                variants.sort((a, b) => {
-                    const aMatch = a.match(/^(\d+(?:\.\d+)?)x SSD$/);
-                    const bMatch = b.match(/^(\d+(?:\.\d+)?)x SSD$/);
+                // Get the variants (note: in k8s world, ssd variants aren't available and 1x is always used)
+                this.$data.availableVariants = droplets.reduce((acc, droplet) => getVariants(droplet, acc), {});
 
-                    if (aMatch && bMatch) return parseFloat(aMatch[1]) - parseFloat(bMatch[1]);
-                    if (aMatch) return -1;
-                    if (bMatch) return 1;
-
-                    return variants.indexOf(a) - variants.indexOf(b);
-                });
-
-                // Set the default variant
-                this.$data.dropletVariant = variants.length ? variants[0] : null;
-
-                // Set the variants for picking (note: in k8s world, variants aren't available and 1x is always used)
-                this.$data.dropletVariants = this.$data.type === 'kubernetes' ? [] : variants;
+                // Ensure the selected variant chain is still valid
+                this.$data.selectedVariants = getValidVariant(this.$data.availableVariants, this.$data.selectedVariants);
 
                 // Set the droplets to show, filtered by variant
-                this.$data.display = droplets.filter(d => d.variant === this.$data.dropletVariant);
+                this.$data.display = droplets.filter(d => compareArrays(d.variant, this.$data.selectedVariants));
             },
-            setDropletVariant(variant) {
-                this.$data.dropletVariant = variant;
-                this.$data.display = this.getDroplets().filter(d => d.variant === this.$data.dropletVariant);
+            setDropletType(type) {
+                this.$data.selectedType = type;
+                this.updateDroplets();
             },
-            toggleType() {
-                this.$data.type = this.$data.type === 'droplet' ? 'kubernetes' : 'droplet';
-
-                // Re-run category setting to deal with kubernetes not using all droplets
-                this.setDropletType(this.$data.dropletType);
+            setDropletVariant(variant, idx) {
+                this.$data.selectedVariants = [
+                    ...this.$data.selectedVariants.slice(0, idx),
+                    variant,
+                    ...this.$data.selectedVariants.slice(idx + 1),
+                ];
+                this.updateDroplets();
+            },
+            toggleType(val) {
+                if (typeof val !== 'boolean') return;
+                this.$data.type = val ? 'kubernetes' : 'droplet';
+                this.updateDroplets();
             },
             picked(slug) {
                 this.$emit('picked', slug, this.$data.type);

--- a/src/bandwidth-tool/templates/picker.vue
+++ b/src/bandwidth-tool/templates/picker.vue
@@ -24,13 +24,13 @@ limitations under the License.
             </ul>
         </div>
 
-        <!--<div class="variants">
+        <div v-if="kubernetes" class="variants">
             <div class="switch">
                 <span>{{ i18n.templates.picker.droplets }}</span>
                 <PrettyCheck class="p-switch p-fill" :checked="type === 'kubernetes'" @change="toggleType"></PrettyCheck>
                 <span>{{ i18n.templates.picker.kubernetes }}</span>
             </div>
-        </div>-->
+        </div>
 
         <div class="variants">
             <div v-for="(selectedVariant, idx) in selectedVariants" class="radio">
@@ -65,7 +65,7 @@ limitations under the License.
     import dropletTypes from '../utils/dropletTypes';
     import kubernetesData from '../../build/kubernetes';
 
-    // import PrettyCheck from 'do-vue/src/templates/pretty-checkbox-vue/pretty_check';
+    import PrettyCheck from 'do-vue/src/templates/pretty-checkbox-vue/pretty_check';
     import PrettyRadio from 'do-vue/src/templates/pretty-checkbox-vue/pretty_radio';
     import { camelToTitleCase } from '../utils/titleCase.js';
     import PickerDroplet from './droplets/picker_droplet';
@@ -153,11 +153,15 @@ limitations under the License.
         name: 'Picker',
         components: {
             PickerDroplet,
-            // PrettyCheck,
+            PrettyCheck,
             PrettyRadio,
         },
         props: {
             droplets: Object,
+            kubernetes: {
+                type: Boolean,
+                default: false,
+            },
         },
         data() {
             return {

--- a/src/build/get.js
+++ b/src/build/get.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ export const get = async url => {
     return await res.json();
 };
 
-export const flatten = (data, type = null, variant = null) => {
+export const flatten = (data, type = null, variant = []) => {
     if (Array.isArray(data)) return data.map(item => ({ ...item, type, variant }));
 
     return Object.keys(data).reduce((acc, key) => {
         return acc.concat(type
-            ? flatten(data[key], type, key)
+            ? flatten(data[key], type, [ ...variant, key ])
             : flatten(data[key], key),
         );
     }, []);


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** Variant handling in data getting
- **Tool Source:** Droplet variants, mainly picking

## What issue does this relate to?

N/A

### What should this PR do?

With the introduction of Premium CPU-optimized Droplets, we now have a combination of Droplets with two variants (Regular/Premium, 1x/2x SSD).

This PR refactors how variants work in the bandwidth tool to ensure that we support nested variants -- when the picker state changes, we generate an object representing all the available variant combinations, and then use an array to track which variant has been picked at each layer in that object. Using that array that tracks the picked variants, we can then directly compare to the variant array on each Droplet's data and filter down to which ones we need to show.

Some other minor UI changes are included in this to support the change from variant being a string to being an array of strings.

### What are the acceptance criteria?

On Droplet types with only a single variant (e.g. Basic with Regular/Premium, or General Purpose with 1x/2x SSD), the variant toggle shows up as expected and selecting a different option shows the expected Droplets in the picker.

On Droplet types with two or more variants (e.g. CPU-Optimized with Regular/Premium + 1x/2x SSD), all the variant options show up as expected, changing a top-level variant persists the lower-level selection (e.g. selecting 2x, changing between Regular/Premium, and 2x being preserved). As any level of variant changes, the displayed Droplets are updated as expected.