### PR TITLE
Fix continual pushes for GH Pages, remove report

### DIFF
--- a/.github/workflows/gh-pages-workflow.yml
+++ b/.github/workflows/gh-pages-workflow.yml
@@ -35,6 +35,9 @@ jobs:
         npm test
         npm run build
 
+    - name: Clean build output
+      run: rm dist/report.html
+
     - name: Deploy master to GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** GitHub Pages workflow

## What issue does this relate to?

cc https://github.com/do-community/available-images/pull/37 https://github.com/do-community/hub-for-good-list/pull/40

### What should this PR do?

Comparing the last two hashes pushed to GitHub Pages, the only difference was the report:

```
git --no-pager diff --no-index --unified=0 ~/Downloads/bandwidth-tool-723f88ba12e7d05f502938ce0fba9aff997be29b ~/Downloads/bandwidth-tool-7cd147aae87f2b445b9cdab49303854f63dbbe0e 
diff --git a/Users/mattcowley/Downloads/bandwidth-tool-723f88ba12e7d05f502938ce0fba9aff997be29b/report.html b/Users/mattcowley/Downloads/bandwidth-tool-7cd147aae87f2b445b9cdab49303854f63dbbe0e/report.html
index 6154786..65dfb82 100644
--- a/Users/mattcowley/Downloads/bandwidth-tool-723f88ba12e7d05f502938ce0fba9aff997be29b/report.html
+++ b/Users/mattcowley/Downloads/bandwidth-tool-7cd147aae87f2b445b9cdab49303854f63dbbe0e/report.html
@@ -6 +6 @@
-    <title>bandwidth-tool [14 May 2023 at 15:09]</title>
+    <title>bandwidth-tool [13 May 2023 at 15:09]</title>
```

We don't actually need that report in the GitHub Pages output at all, and it is causing us to push every single run, rather than only when the output actually changes. This PR removes the report from the output so that we don't continually push to pages.

### What are the acceptance criteria?

Report removed from GitHub Pages output.
